### PR TITLE
Fixed version conflict with dart 2.1.0/flutter 0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
     sdk: flutter
   http: ">=0.11.3+16 <0.12.0"
 
+environment:
+  sdk: ">=2.0.0-dev.58.0 <3.0.0"
+
 flutter:
   plugin:
     androidPackage: io.github.nitishk72.youtubeapi.youtubeapi


### PR DESCRIPTION
Check https://github.com/flutter/flutter/issues/20700 for more info.

Issue is resolved by just setting a minimum environment version for the
plugin.

Closes:
https://github.com/nitishk72/youtube_api/issues/1