### PR TITLE
update the search method to be able to search videos in the specific …

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ videoResult = await ytApi.search(query);
 // data which are available in videoResult are shown below
 ```
 
+To search for videos in the specific Channel-
+
+```dart
+String query = "Flutter";
+String channelId = "testChannelId";
+videoResult = await ytApi.search(query, type: "video", channelId: channelId,);
+// data which are available in videoResult are shown below
+```
+
 To get Trending videos in your Country-
 
 ```dart

--- a/lib/src/util/_api.dart
+++ b/lib/src/util/_api.dart
@@ -26,6 +26,7 @@ class ApiHelper {
     String query, {
     String? type,
     String? regionCode,
+    String? channelId,
     required String videoDuration,
     required String order,
   }) {
@@ -41,6 +42,7 @@ class ApiHelper {
       "order": order,
       "videoDuration": videoDuration,
     };
+    if (this.channelId != null) options['channelId'] = this.channelId!;
     if (regionCode != null) options['regionCode'] = regionCode;
     print(options);
     Uri url = new Uri.https(baseURL, "youtube/v3/search", options);

--- a/lib/youtube_api.dart
+++ b/lib/youtube_api.dart
@@ -51,6 +51,7 @@ class YoutubeAPI {
     String order = 'relevance',
     String videoDuration = 'any',
     String? regionCode,
+    String? channelId,
   }) async {
     this.getTrending = false;
     this.query = query;
@@ -60,6 +61,7 @@ class YoutubeAPI {
       videoDuration: videoDuration,
       order: order,
       regionCode: regionCode,
+      channelId: channelId,
     );
     var res = await http.get(url, headers: headers);
     var jsonData = json.decode(res.body);


### PR DESCRIPTION
# Issue
https://github.com/nstack-in/youtube_api/issues/40

# Why
I would like to search videos in the specific channel.

# What
- update the `search` function in `src/youtube_api.dart` to receive `channelId` as an argument and pass it to `searchUri` function.
- update the `searchUri` function in `src/util/_api.dart` to receive `channelId` as an argument and convert it to the url option.
- update README