### PR TITLE
Add 'videosById' method

### DIFF
--- a/lib/youtube_api.dart
+++ b/lib/youtube_api.dart
@@ -85,6 +85,22 @@ class YoutubeAPI {
   }
 
   /*
+   Get YouTubeVideos from video Id
+    */
+  Future<List<YouTubeVideo>> videosById(List<String> videoIds) async {
+    this.getTrending = true;
+    final url = api!.videoUri(videoIds, snippet: true);
+    var res = await http.get(url, headers: headers);
+    var jsonData = json.decode(res.body);
+    if (jsonData['error'] != null) {
+      throw jsonData['error']['message'];
+    }
+    if (jsonData['pageInfo']['totalResults'] == null) return <YouTubeVideo>[];
+    List<YouTubeVideo> result = await _getResultFromJson(jsonData);
+    return result;
+  }
+
+  /*
   Get video details from video Id
    */
   Future<List<Video>> video(List<String> videoId) async {


### PR DESCRIPTION
# Why
I would like to fetch data as YouTubeVideo model instance by video ids.

# What
Add `videosById` method which can fetch data as YouTubeVideo model instance to the youtube_api.dart

# Description
Now, we can fetch data as Video model instances by video ids.
But, Video model is different from YouTubeVideo model and it is difficult to convert it.
So create the method!

# Issue
https://github.com/nstack-in/youtube_api/issues/33