### PR TITLE
Update http Package Version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.13.3
+  http: ^1.2.1
   collection: ^1.15.0
   enum_to_string: ^2.0.1
   iso8601_duration: ^0.0.4


### PR DESCRIPTION
- This package uses http version 0.13.3
- Various other packages that depend on a newer version of http (such as google_fonts, firebase etc) are held back due to the dependency constraint of http 0.13.3
- This update simply bumps the http version to the latest available, currently (6th March 2024)
- I have tested the example app and everything seems to be working :)

Thanks to the original developers and all contributors for creating and maintaining such an incredible package.