### PR TITLE
Add channelId and publishedAfter/publishedBefore filters to search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- Add optional channelId and publishedAfter/publishedBefore filters to search.
+
 ## [1.1.0] - August 14th 2020
 
 - Initial version of youtube_api_client. (Starting after youtube_api package fork on version 1.0.3).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ result = await youtube.search(query);
 // data which are available in result is typed as in the example shown below
 ```
 
+Filter by channel and publish time:
+
+```dart
+result = await youtube.search(
+  query,
+  channelId: 'UCxxxxxxxxxxxxxxxxxxxx',
+  publishedAfter: DateTime.utc(2024, 1, 1),
+  publishedBefore: DateTime.utc(2024, 1, 31, 23, 59, 59),
+);
+```
+
 By default the search options are like the following:
 
 ```dart

--- a/lib/youtube_api.dart
+++ b/lib/youtube_api.dart
@@ -50,8 +50,16 @@ class YoutubeApi {
       order: Order.relevance,
       videoDuration: VideoDuration.any,
     ),
+    String? channelId,
+    DateTime? publishedAfter,
+    DateTime? publishedBefore,
   }) async {
-    searchOptions = options.copyWith(query: query);
+    searchOptions = options.copyWith(
+      query: query,
+      channelId: channelId,
+      publishedAfter: publishedAfter,
+      publishedBefore: publishedBefore,
+    );
     final url = _getSearchUri(options: searchOptions);
     var res = await http.get(url, headers: headers);
     var jsonData = json.decode(res.body);


### PR DESCRIPTION
## Summary
- Add optional channelId and publishedAfter/publishedBefore parameters to search()
- Update README with usage example
- Update CHANGELOG

## Motivation
Enable filtering search results by channel and date range without custom URL handling.

## Notes
No breaking changes; new parameters are optional.
